### PR TITLE
refactor: comment out Route53 and ACM from app1

### DIFF
--- a/terraform/provider/aws/stacks/app1/main.tf
+++ b/terraform/provider/aws/stacks/app1/main.tf
@@ -115,76 +115,52 @@ resource "aws_lb_target_group_attachment" "main" {
 }
 
 # ACM Certificate
-resource "aws_acm_certificate" "main" {
-  count             = var.domain_name != "" ? 1 : 0
-  domain_name       = var.domain_name
-  validation_method = "DNS"
+# # ACM Certificate
+# resource "aws_acm_certificate" "main" {
+#   count             = var.domain_name != "" ? 1 : 0
+#   domain_name       = var.domain_name
+#   validation_method = "DNS"
+#
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+#
+#   tags = {
+#     Name        = "${var.project_name}-cert"
+#     Environment = var.environment
+#   }
+# }
 
-  lifecycle {
-    create_before_destroy = true
-  }
+# # Route53 Record for Certificate Validation
+# resource "aws_route53_record" "cert_validation" {
+#   for_each = var.domain_name != "" ? {
+#     for dvo in aws_acm_certificate.main[0].domain_validation_options : dvo.domain_name => {
+#       name   = dvo.resource_record_name
+#       record = dvo.resource_record_value
+#       type   = dvo.resource_record_type
+#     }
+#   } : {}
+#
+#   allow_overwrite = true
+#   name            = each.value.name
+#   records         = [each.value.record]
+#   ttl             = 60
+#   type            = each.value.type
+#   zone_id         = var.route53_zone_id
+# }
 
-  tags = {
-    Name        = "${var.project_name}-cert"
-    Environment = var.environment
-  }
-}
+# # Certificate Validation
+# resource "aws_acm_certificate_validation" "main" {
+#   count                   = var.domain_name != "" ? 1 : 0
+#   certificate_arn         = aws_acm_certificate.main[0].arn
+#   validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+# }
 
-# Route53 Record for Certificate Validation
-resource "aws_route53_record" "cert_validation" {
-  for_each = var.domain_name != "" ? {
-    for dvo in aws_acm_certificate.main[0].domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  } : {}
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = var.route53_zone_id
-}
-
-# Certificate Validation
-resource "aws_acm_certificate_validation" "main" {
-  count                   = var.domain_name != "" ? 1 : 0
-  certificate_arn         = aws_acm_certificate.main[0].arn
-  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
-}
-
-# ALB Listener - HTTP (redirect to HTTPS)
+# ALB Listener - HTTP
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.main.arn
   port              = "80"
   protocol          = "HTTP"
-
-  default_action {
-    type = var.domain_name != "" ? "redirect" : "forward"
-
-    dynamic "redirect" {
-      for_each = var.domain_name != "" ? [1] : []
-      content {
-        port        = "443"
-        protocol    = "HTTPS"
-        status_code = "HTTP_301"
-      }
-    }
-
-    target_group_arn = var.domain_name == "" ? aws_lb_target_group.main.arn : null
-  }
-}
-
-# ALB Listener - HTTPS
-resource "aws_lb_listener" "https" {
-  count             = var.domain_name != "" ? 1 : 0
-  load_balancer_arn = aws_lb.main.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = aws_acm_certificate_validation.main[0].certificate_arn
 
   default_action {
     type             = "forward"
@@ -192,16 +168,31 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-# Route53 Record for ALB
-resource "aws_route53_record" "alb" {
-  count   = var.domain_name != "" ? 1 : 0
-  zone_id = var.route53_zone_id
-  name    = var.domain_name
-  type    = "A"
+# # ALB Listener - HTTPS
+# resource "aws_lb_listener" "https" {
+#   count             = var.domain_name != "" ? 1 : 0
+#   load_balancer_arn = aws_lb.main.arn
+#   port              = "443"
+#   protocol          = "HTTPS"
+#   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+#   certificate_arn   = aws_acm_certificate_validation.main[0].certificate_arn
+#
+#   default_action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.main.arn
+#   }
+# }
 
-  alias {
-    name                   = aws_lb.main.dns_name
-    zone_id                = aws_lb.main.zone_id
-    evaluate_target_health = true
-  }
-}
+# # Route53 Record for ALB
+# resource "aws_route53_record" "alb" {
+#   count   = var.domain_name != "" ? 1 : 0
+#   zone_id = var.route53_zone_id
+#   name    = var.domain_name
+#   type    = "A"
+#
+#   alias {
+#     name                   = aws_lb.main.dns_name
+#     zone_id                = aws_lb.main.zone_id
+#     evaluate_target_health = true
+#   }
+# }

--- a/terraform/provider/aws/stacks/app1/outputs.tf
+++ b/terraform/provider/aws/stacks/app1/outputs.tf
@@ -30,5 +30,5 @@ output "alb_dns_name" {
 
 output "alb_url" {
   description = "Application Load Balancer URL"
-  value       = var.domain_name != "" ? "https://${var.domain_name}" : "http://${aws_lb.main.dns_name}"
+  value       = "http://${aws_lb.main.dns_name}"
 }


### PR DESCRIPTION
Removes Route53 and ACM resources from app1 stack.

**Changes:**
- Commented out Route53 records (cert validation + ALB alias)
- Commented out ACM certificate and validation
- Commented out HTTPS listener
- Simplified HTTP listener to always forward
- Simplified alb_url output