### PR TITLE
security: move EC2 to private subnets, ALB-only traffic

### DIFF
--- a/terraform/modules/aws/compute/ec2/main.tf
+++ b/terraform/modules/aws/compute/ec2/main.tf
@@ -113,9 +113,9 @@ resource "aws_security_group" "ec2" {
     from_port       = 80
     to_port         = 80
     protocol        = "tcp"
-    cidr_blocks     = var.alb_security_group_id != "" ? [] : ["0.0.0.0/0"]
     security_groups = var.alb_security_group_id != "" ? [var.alb_security_group_id] : []
-    description     = "HTTP from ALB or internet"
+    cidr_blocks     = var.alb_security_group_id != "" ? [] : ["0.0.0.0/0"]
+    description     = "HTTP from ALB"
   }
 
   egress {
@@ -143,7 +143,7 @@ resource "aws_instance" "this" {
   iam_instance_profile        = aws_iam_instance_profile.ec2.name
   key_name                    = var.key_name != "" ? var.key_name : null
   user_data                   = var.user_data != "" ? var.user_data : null
-  associate_public_ip_address = true
+  associate_public_ip_address = false
 
   metadata_options {
     http_endpoint = "enabled"

--- a/terraform/provider/aws/stacks/app1/main.tf
+++ b/terraform/provider/aws/stacks/app1/main.tf
@@ -54,7 +54,7 @@ module "ec2" {
 
   project_name            = var.project_name
   vpc_id                  = module.vpc.vpc_id
-  subnet_ids              = module.vpc.public_subnet_ids
+  subnet_ids              = module.vpc.private_subnet_ids
   instance_type           = var.instance_type
   instance_count          = var.instance_count
   key_name                = var.key_name


### PR DESCRIPTION
Moves EC2 instances to private subnets and restricts inbound traffic to ALB only.

**Changes:**
- EC2 subnet_ids changed from public to private
- Disabled public IP on EC2 instances
- Security group allows port 80 from ALB SG only